### PR TITLE
fix texts and links

### DIFF
--- a/activity/index.html
+++ b/activity/index.html
@@ -106,7 +106,7 @@
     </div>
     <h3 id="links">ロ技研リンク集</h3>
     <ul>
-      <li><a href="http://rogiken.org/">東京科学大学ロボット技術研究会</a> ロ技研の公式ページです</li>
+      <li><a href="http://www.rogiken.org/">東京科学大学ロボット技術研究会</a> ロ技研の公式ページです</li>
       <li><a href="https://twitter.com/titech_ssr">Twitter: @titech_ssr</a> ロ技研のTwitterアカウントです</li>
       <li><a href="http://titech-ssr.blog.jp/">ロ技研ブログ</a> ロ技研の活動報告のブログです</li>
       <li><a href="https://www.isct.ac.jp/">東京科学大学（旧東京工業大学）</a> 東京科学大学ホームページ</li>

--- a/activity/index.html
+++ b/activity/index.html
@@ -4,9 +4,9 @@
 <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta charset="utf-8">
-    <title>東京工業大学 ロボット技術研究会</title>
-    <meta name="description" content="ロボット技術研究会は、機械工作・電子工作・プログラミングなどのものつくり活動を行う東京工業大学の公認サークルです。">
-    <meta name="author" content="東京工業大学 ロボット技術研究会">
+    <title>東京科学大学 ロボット技術研究会</title>
+    <meta name="description" content="ロボット技術研究会は、機械工作・電子工作・プログラミングなどのものつくり活動を行う東京科学大学の公認サークルです。">
+    <meta name="author" content="東京科学大学 ロボット技術研究会">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <link href="/css/bootstrap.min.css" rel="stylesheet">
     <link href="lightbox.css" rel="stylesheet">
@@ -51,8 +51,8 @@
 
   <div id="top-short">
     <div class="container">
-      <h1>東京工業大学 ロボット技術研究会</h1>
-      <p>ロボット技術研究会は、機械工作・電子工作・プログラミングなどのものつくり活動を行う東京工業大学の公認サークルです。</p>
+      <h1>東京科学大学 ロボット技術研究会</h1>
+      <p>ロボット技術研究会は、機械工作・電子工作・プログラミングなどのものつくり活動を行う東京科学大学の公認サークルです。</p>
     </div>
   </div>
 
@@ -62,7 +62,7 @@
     <p>部の存在の目的は、主に部員の研究活動に関する相互扶助です。そのため、特に部全体で何かのコンテストを目標にするといった活動は一切行いません。様々な部員の研究や活動の記録が、そのままロ技研の研究・活動になります。 
     </p>
     <h3>ロ技研の年間イベント</h3>
-    <p>ロボット技術研究会では、東工大の大学祭「工大祭」と、春の新歓活動が年に2回の対外的な研究発表の場となりますが、各活動グループ単位でコンテスト（NHKロボコン、ROBO-ONEなど）への参加することも積極的に行われています。 
+    <p>ロボット技術研究会では、東京科学大学の大学祭と、春の新歓活動が年に2回の対外的な研究発表の場となりますが、各活動グループ単位でコンテスト（NHKロボコン、ROBO-ONEなど）への参加することも積極的に行われています。 
 また、ロ技研内部では年2回の「研究報告会」、小規模の勉強会である「rogyゼミ」もあり、お互いの技術力・知識を共有しています。</p>
     <h3 id="ssr_laboratory">ロ技研の研究室</h3>
     <p>ロ技研では「研究室」（と呼ばれる小さな構成単位毎に自由に活動しています。）にわかれ、各研究室が独自にテーマを設けて研究活動を行っています。（この研究室は大学の研究室とは一切関係はありません。） 
@@ -106,10 +106,11 @@
     </div>
     <h3 id="links">ロ技研リンク集</h3>
     <ul>
-      <li><a href="http://rogiken.org/">東京工業大学ロボット技術研究会</a> ロ技研の公式ページです</li>
+      <li><a href="http://rogiken.org/">東京科学大学ロボット技術研究会</a> ロ技研の公式ページです</li>
       <li><a href="https://twitter.com/titech_ssr">Twitter: @titech_ssr</a> ロ技研のTwitterアカウントです</li>
       <li><a href="http://titech-ssr.blog.jp/">ロ技研ブログ</a> ロ技研の活動報告のブログです</li>
-      <li><a href="http://www.titech.ac.jp/">東京工業大学</a></li>
+      <li><a href="https://www.isct.ac.jp/">東京科学大学（旧東京工業大学）</a> 東京科学大学ホームページ</li>
+      <li><a href="http://www.titech.ac.jp/">東京工業大学</a> 東京工業大学ホームページ</li>
     </ul>  
   </div>
   <div class="container footer">

--- a/shinkan/2025/index.html
+++ b/shinkan/2025/index.html
@@ -222,7 +222,7 @@
       <div class="container footer">
         <p>ロボット技術研究会 オフィシャルメールアドレスは、
           <mark>info (at) rogiken.org</mark> です。(at)を @ に変えて送って下さい。 </p>
-        <p>Copyright © 2024 Tokyo Tech Society for the Study of Robotics. All Rights Reserved.</p>
+        <p>Copyright © 2025 Tokyo Tech Society for the Study of Robotics. All Rights Reserved.</p>
       </div>
     </footer>
   </body>

--- a/shinkan/2025/links.html
+++ b/shinkan/2025/links.html
@@ -172,7 +172,7 @@
                     <hr></hr>
                     <ul>
                       <li>
-                        <a href="http://rogiken.org/">東京科学大学ロボット技術研究会</a> ロ技研の公式ページです</li>
+                        <a href="http://www.rogiken.org/">東京科学大学ロボット技術研究会</a> ロ技研の公式ページです</li>
                       <li>
                         <a href="https://twitter.com/titech_ssr">Twitter: @titech_ssr</a> ロ技研のTwitterアカウントです</li>
                       <li>

--- a/shinkan/2025/src/links.ejs
+++ b/shinkan/2025/src/links.ejs
@@ -3,7 +3,7 @@
         <h2>リンク集</h2>
         <hr></hr>
         <ul>
-            <li><a href="http://rogiken.org/">東京科学大学ロボット技術研究会</a> ロ技研の公式ページです</li>
+            <li><a href="http://www.rogiken.org/">東京科学大学ロボット技術研究会</a> ロ技研の公式ページです</li>
             <li><a href="https://twitter.com/titech_ssr">Twitter: @titech_ssr</a> ロ技研のTwitterアカウントです</li>
             <li><a href="http://twitter.com/ssr_welcome/">Twitter: @ssr_welcome</a> 新歓用のTwitterアカウントです</li>
             <li><a href="https://blog.rogiken.org/">ロ技研ブログ</a> ロ技研の活動報告のブログです</li>


### PR DESCRIPTION
2025、東京科学大学に変更できていなかった場所があったので更新
`https://rogiken.org`のままのところがあったので`https://www.rogiken.org`に更新